### PR TITLE
Get Questions endpoint

### DIFF
--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -1,0 +1,1 @@
+class Api::V1::QuestionsController < ApplicationController

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -1,1 +1,11 @@
 class Api::V1::QuestionsController < ApplicationController
+  def index
+    questions = Question.includes(:answers)
+
+    if questions.empty?
+      render json: { data: [], message: "No questions available at this time." }, status: :ok
+    else
+      render json: QuestionsSerializer.new(questions), status: :ok
+    end
+  end
+end

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::QuestionsController < ApplicationController
     if questions.empty?
       render json: { data: [], message: "No questions available at this time." }, status: :ok
     else
-      render json: QuestionsSerializer.new(questions), status: :ok
+      render json: QuestionSerializer.new(questions), status: :ok
     end
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,4 +2,6 @@ class Answer < ApplicationRecord
   belongs_to :question
   has_many :submission_answers
   has_many :recommended_animals_weights
+
+  validates :text, presence: true
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,3 +1,5 @@
 class Question < ApplicationRecord
-  has_many :answers
+  has_many :answers, dependent: :destroy
+
+  validates :text, presence: true
 end

--- a/app/serializers/answer_serializer.rb
+++ b/app/serializers/answer_serializer.rb
@@ -1,0 +1,5 @@
+class AnswerSerializer
+  include JSONAPI::Serializer
+
+  attributes :text
+end

--- a/app/serializers/question_serializer.rb
+++ b/app/serializers/question_serializer.rb
@@ -1,0 +1,6 @@
+class QuestionSerializer
+  include JSONAPI::Serializer
+
+  attributes :text
+  has_many :answers
+end

--- a/app/serializers/question_serializer.rb
+++ b/app/serializers/question_serializer.rb
@@ -2,5 +2,16 @@ class QuestionSerializer
   include JSONAPI::Serializer
 
   attributes :text
-  has_many :answers
+  
+  attribute :answers do |question|
+    question.answers.map do |answer|
+      {
+        id: answer.id.to_s,
+        type: "answer",
+        attributes: {
+          text: answer.text
+        }
+      }
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, only: :create
+      resources :questions, only: :index
     end
   end
 end

--- a/docs/json_contracts.md
+++ b/docs/json_contracts.md
@@ -80,8 +80,6 @@ response:
       "id": 1,
       "attributes": {
         "text": "question?",
-      },
-      "relationships": {
         "answers": {
           "data": [
             {
@@ -90,11 +88,11 @@ response:
               "attributes": {
                 "text": "answer"
               }
-            }, ...
+            }
           ]
         }
       }
-    }, ...
+    }
   ]
 }
 ```

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -6,4 +6,9 @@ RSpec.describe Answer, type: :model do
     it { is_expected.to have_many :submission_answers }
     it { is_expected.to have_many :recommended_animals_weights }
   end
+
+  describe "Validations" do
+    it { is_expected.to validate_presence_of :text }
+  end
 end
+

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -4,4 +4,8 @@ RSpec.describe Question, type: :model do
   describe "Relationships" do
     it { is_expected.to have_many :answers }
   end
+
+  describe "Validations" do
+    it { is_expected.to validate_presence_of :text }
+  end
 end

--- a/spec/requests/api/v1/questions_request_spec.rb
+++ b/spec/requests/api/v1/questions_request_spec.rb
@@ -21,11 +21,14 @@ RSpec.describe "Questions API", type: :request do
           expect(question).to have_key(:id)
           expect(question[:type]).to eq("question")
           expect(question[:attributes]).to have_key(:text)
-          expect(question[:relationships][:answers][:data]).count.to eq(3)
+          expect(question[:attributes]).to have_key(:answers)
 
-          question[:relationships][:answers][:data].each do |answer|
+          answers = question[:attributes][:answers]
+          expect(answers.count).to eq(3)
+
+          answers.each do |answer|
             expect(answer[:type]).to eq("answer")
-            expect(answer[:attributes].to have_key(:text))
+            expect(answer[:attributes]).to have_key(:text)
             expect(answer[:id]).to be_a(String)
           end
         end
@@ -34,9 +37,9 @@ RSpec.describe "Questions API", type: :request do
 
     context "with invalid request" do
       it "returns 404 for an invalid endpoint" do
-        get "/api/v1/questionz"
-      
-        expect(response.status).to eq(404)
+        expect {
+          get "/api/v1/questionz"
+        }.to raise_error(ActionController::RoutingError)
       end
     end
 
@@ -44,7 +47,7 @@ RSpec.describe "Questions API", type: :request do
       it "returns an empty array if there are no questions" do 
         Question.destroy_all 
 
-        get "api/v1/questions"
+        get "/api/v1/questions"
 
         expect(response).to be_successful
         json = JSON.parse(response.body, symbolize_names: true)

--- a/spec/requests/api/v1/questions_request_spec.rb
+++ b/spec/requests/api/v1/questions_request_spec.rb
@@ -33,7 +33,22 @@ RSpec.describe "Questions API", type: :request do
     end
 
     context "with invalid request" do
-      it 
+      it "returns 404 for an invalid endpoint" do
+        get "/api/v1/questionz"
+      
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "with empty database" do 
+      Question.destroy_all 
+      it "returns an empty array if there are no questions" do 
+        get "api/v1/questions"
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(json[:data]).to eq([])
+      end
     end
   end 
 end

--- a/spec/requests/api/v1/questions_request_spec.rb
+++ b/spec/requests/api/v1/questions_request_spec.rb
@@ -43,12 +43,13 @@ RSpec.describe "Questions API", type: :request do
     context "with empty database" do 
       it "returns an empty array if there are no questions" do 
         Question.destroy_all 
-        
+
         get "api/v1/questions"
 
         expect(response).to be_successful
         json = JSON.parse(response.body, symbolize_names: true)
         expect(json[:data]).to eq([])
+        expect(json[:message]).to eq("No questions available at this time.")
       end
     end
   end 

--- a/spec/requests/api/v1/questions_request_spec.rb
+++ b/spec/requests/api/v1/questions_request_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper" 
+
+RSpec.describe "Questions API", type: :request do
+  describe "Get Questions Endpoint" do 
+    before(:each) do 
+      @question1 = create(:question)
+      create_list(:answer, 3, question: @question1)
+      @question2 = create(:question)
+      create_list(:answer, 3, question: @question2)
+    end
+
+    context "with valid request" do
+      it "returns all questions with their related answers" do 
+        get "/api/v1/questions"
+
+        expect(response).to be_successful 
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(json[:data].count).to eq(2)
+
+        json[:data].each do |question|
+          expect(question).to have_key(:id)
+          expect(question[:type]).to eq("question")
+          expect(question[:attributes]).to have_key(:text)
+          expect(question[:relationships][:answers][:data]).count.to eq(3)
+
+          question[:relationships][:answers][:data].each do |answer|
+            expect(answer[:type]).to eq("answer")
+            expect(answer[:attributes].to have_key(:text))
+            expect(answer[:id]).to be_a(String)
+          end
+        end
+      end
+    end
+
+    context "with invalid request" do
+      it 
+    end
+  end 
+end

--- a/spec/requests/api/v1/questions_request_spec.rb
+++ b/spec/requests/api/v1/questions_request_spec.rb
@@ -41,8 +41,9 @@ RSpec.describe "Questions API", type: :request do
     end
 
     context "with empty database" do 
-      Question.destroy_all 
       it "returns an empty array if there are no questions" do 
+        Question.destroy_all 
+        
         get "api/v1/questions"
 
         expect(response).to be_successful


### PR DESCRIPTION
# Pull Request

## Type of change

- [x] New feature
- [ ] Bug Fix

## Check the correct boxes

- [x] This code broke nothing
- [ ] This code broke some stuff
- [ ] This code broke everything

## Implements/Fixes

- Built GET /api/v1/questions endpoint to return all questions along with their related answers
- Used includes(:answers) in the controller to eager load associated answers, preventing N+1 queries and improving performance when serializing nested data
- Customized the QuestionSerializer to nest answers inside the attributes block of each question, aligning with the agreed-upon JSON contract, but slightly differing in format. AnswerSerializer is untouched and unused so far in this context.
- Added request specs for GET /api/v1/questions, covering happy and edge cases
- Wrote model specs to validate presence of text on questions and answers
- Customized request spec to match the nested answers structure in the serialized response
- Confirmed each nested answer includes id, type, and text
- Added a sad path spec to assert ActionController::RoutingError is raised for invalid routes like /api/v1/questionz

- Closes #3 

## Testing Changes

- [x] I have fully tested my code
- [x] All tests are passing
- [ ] Some tests are failing
- [ ] All tests are failing

- [x] No previous tests have been changed
- [ ] Some previous tests have been changed
- [ ] All of the previous tests have been changed (Please describe what in the world happened that all of the previous tests needed changing.)

## Checklist

- [x] I have reviewed my code
- [x] The code will run locally

## (Optional) What questions do you have? Anything specific you want feedback on?

-In order to return answers nested under each question, I customized the QuestionSerializer to include answers inside the attributes block rather than using the default has_many :answers relationship. This breaks from standard JSON:API conventions and bypasses the relationships key, meaning we’re not currently using the AnswerSerializer.

The current response differs slightly from the JSON contract in the ticket — just checking if this approach works for everyone. I couldn’t get the relationships[:answers][:data] structure to include the full answer objects and pass the tests. Open to refactoring if we want to align more closely with JSON:API or revisit the contract.

## (For Fun!) Please include a link to a gif [or add an emoji] of your feelings about this branch

![Link](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXFpdjEzcHNzMHA4aHVlMGk3NGtnaHYyZ2RvcnY4YjlybDVtbW44NiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/OCu7zWojqFA1W/giphy.gif)
